### PR TITLE
FEATURE: Add Admin Assistant chat ingestion

### DIFF
--- a/app/controllers/ask_discourse_context/admin_assistant_chats_controller.rb
+++ b/app/controllers/ask_discourse_context/admin_assistant_chats_controller.rb
@@ -4,6 +4,8 @@ module AskDiscourseContext
   class AdminAssistantChatsController < ::Admin::AdminController
     requires_plugin PLUGIN_NAME
 
+    before_action :ensure_sync_enabled
+
     def update
       AdminAssistantChat::Sync.call(
         service_params.deep_merge(params: { external_id: params[:external_id] }),
@@ -16,6 +18,14 @@ module AskDiscourseContext
         on_failed_policy(:agent_can_receive_chat) { raise Discourse::InvalidAccess }
         on_failed_policy(:admin_can_sync_chat) { raise Discourse::InvalidAccess }
         on_failure { render_json_error(I18n.t("ask_discourse_context.sync_failed")) }
+      end
+    end
+
+    private
+
+    def ensure_sync_enabled
+      if !SiteSetting.ask_discourse_context_admin_assistant_chat_sync_enabled
+        raise Discourse::NotFound
       end
     end
   end

--- a/app/controllers/ask_discourse_context/admin_assistant_chats_controller.rb
+++ b/app/controllers/ask_discourse_context/admin_assistant_chats_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module AskDiscourseContext
+  class AdminAssistantChatsController < ::Admin::AdminController
+    requires_plugin PLUGIN_NAME
+
+    def update
+      AdminAssistantChat::Sync.call(
+        service_params.deep_merge(params: { external_id: params[:external_id] }),
+      ) do
+        on_success { head :no_content }
+        on_failed_contract do |contract|
+          render_json_error(contract.errors.full_messages, status: :bad_request)
+        end
+        on_model_not_found(:agent) { raise Discourse::NotFound }
+        on_failed_policy(:agent_can_receive_chat) { raise Discourse::InvalidAccess }
+        on_failed_policy(:admin_can_sync_chat) { raise Discourse::InvalidAccess }
+        on_failure { render_json_error(I18n.t("ask_discourse_context.sync_failed")) }
+      end
+    end
+  end
+end

--- a/app/services/ask_discourse_context/admin_assistant_chat/sync.rb
+++ b/app/services/ask_discourse_context/admin_assistant_chat/sync.rb
@@ -142,11 +142,12 @@ module AskDiscourseContext
       end
 
       def fetch_agent
-        AiAgent.find_by(id: ADMIN_ASSISTANT_AGENT_ID)
+        AiAgent.find_by(id: SiteSetting.ask_discourse_context_admin_assistant_agent_id)
       end
 
       def agent_can_receive_chat(agent:)
-        agent.user_id == ADMIN_ASSISTANT_USER_ID && agent.user&.active? && agent.user.bot?
+        agent.user_id == SiteSetting.ask_discourse_context_admin_assistant_user_id &&
+          agent.user&.active? && agent.user.bot?
       end
 
       def create_staged_user(params:)

--- a/app/services/ask_discourse_context/admin_assistant_chat/sync.rb
+++ b/app/services/ask_discourse_context/admin_assistant_chat/sync.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+module AskDiscourseContext
+  module AdminAssistantChat
+    class Sync
+      include Service::Base
+
+      MAX_MESSAGES = 1_000
+      MAX_TOTAL_RAW_BYTES = 10.megabytes
+      EXTERNAL_ID_PATTERN = /\A[\w-]+\z/
+      ROLES = %w[admin assistant].freeze
+
+      params do
+        attribute :external_id, :string
+        attribute :user_unique_id, :string
+        attribute :preferred_username, :string
+        attribute :title, :string
+        attribute :messages, :array
+
+        validates :external_id,
+                  presence: true,
+                  length: {
+                    maximum: Topic::EXTERNAL_ID_MAX_LENGTH,
+                  },
+                  format: {
+                    with: EXTERNAL_ID_PATTERN,
+                  }
+        validates :user_unique_id, presence: true, length: { maximum: 500 }
+        validates :preferred_username, presence: true, length: { maximum: User.username_length.max }
+        validates :title,
+                  presence: true,
+                  length: {
+                    in: SiteSetting.min_topic_title_length..SiteSetting.max_topic_title_length,
+                  }
+        validates :messages, length: { maximum: MAX_MESSAGES }
+        validate :messages_are_valid
+
+        private
+
+        def messages_are_valid
+          if !messages.is_a?(Array)
+            errors.add(:messages, :invalid)
+            return
+          end
+
+          normalized_messages =
+            messages.filter_map do |message|
+              attributes = message.respond_to?(:to_unsafe_h) ? message.to_unsafe_h : message.to_h
+              attributes.stringify_keys
+            end
+          if normalized_messages.size != messages.size
+            errors.add(:messages, :invalid)
+            return
+          end
+
+          validate_message_ids(normalized_messages)
+          validate_message_attributes(normalized_messages)
+          validate_total_raw_size(normalized_messages)
+        rescue NoMethodError, TypeError
+          errors.add(:messages, :invalid)
+        end
+
+        def validate_message_ids(messages)
+          ids = messages.map { |message| message["external_id"].to_s }
+          if ids.any?(&:blank?) || ids.any? { |id| id.length > 100 } || ids.uniq.size != ids.size
+            errors.add(:messages, :invalid)
+          end
+        end
+
+        def validate_message_attributes(messages)
+          previous_created_at = nil
+
+          messages.each do |message|
+            errors.add(:messages, :invalid) if !ROLES.include?(message["role"])
+
+            raw = message["raw"]
+            if !raw.is_a?(String) || raw.length > SiteSetting.max_post_length
+              errors.add(:messages, :invalid)
+            end
+
+            created_at = parse_timestamp(message["created_at"])
+            updated_at = parse_timestamp(message["updated_at"])
+            deleted_at =
+              message["deleted_at"].present? ? parse_timestamp(message["deleted_at"]) : nil
+
+            errors.add(:messages, :invalid) if !created_at || !updated_at
+            errors.add(:messages, :invalid) if created_at && updated_at && updated_at < created_at
+            errors.add(:messages, :invalid) if created_at && deleted_at && deleted_at < created_at
+            if previous_created_at && created_at && created_at < previous_created_at
+              errors.add(:messages, :invalid)
+            end
+
+            previous_created_at = created_at if created_at
+          end
+        end
+
+        def validate_total_raw_size(messages)
+          total_raw_bytes = messages.sum { |message| message["raw"].to_s.bytesize }
+          errors.add(:messages, :invalid) if total_raw_bytes > MAX_TOTAL_RAW_BYTES
+        end
+
+        def parse_timestamp(value)
+          Time.iso8601(value.to_s)
+        rescue ArgumentError
+          nil
+        end
+      end
+
+      policy :admin_can_sync_chat
+      model :snapshot, :build_snapshot
+
+      only_if :chat_should_sync do
+        model :agent
+        policy :agent_can_receive_chat
+
+        lock :external_id do
+          try(
+            ActiveRecord::ActiveRecordError,
+            Discourse::InvalidParameters,
+            AdminAssistantChatSynchronizer::AuthorConflict,
+            AdminAssistantChatSynchronizer::TopicConflict,
+            StagedUser::InvalidUser,
+          ) do
+            model :staged_user, :create_staged_user
+            step :synchronize_chat
+          end
+        end
+      end
+
+      private
+
+      def admin_can_sync_chat(guardian:)
+        guardian.is_admin?
+      end
+
+      def build_snapshot(params:)
+        AdminAssistantChatSnapshot.new(params.messages)
+      end
+
+      def chat_should_sync(params:, snapshot:)
+        snapshot.opening_message || Topic.with_deleted.exists?(external_id: params.external_id)
+      end
+
+      def fetch_agent
+        AiAgent.find_by(id: ADMIN_ASSISTANT_AGENT_ID)
+      end
+
+      def agent_can_receive_chat(agent:)
+        agent.user_id == ADMIN_ASSISTANT_USER_ID && agent.user&.active? && agent.user.bot?
+      end
+
+      def create_staged_user(params:)
+        StagedUser.find_or_create!(
+          unique_id: params.user_unique_id,
+          preferred_username: params.preferred_username,
+        )
+      end
+
+      def synchronize_chat(params:, guardian:, agent:, snapshot:, staged_user:)
+        AdminAssistantChatSynchronizer.new(
+          actor: guardian.user,
+          agent_user: agent.user,
+          external_id: params.external_id,
+          snapshot: snapshot,
+          staged_user: staged_user,
+          title: params.title,
+        ).sync
+      end
+    end
+  end
+end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,3 +1,7 @@
 en:
+  site_settings:
+    ask_discourse_context_admin_assistant_user_id: "User ID that authors imported Admin Assistant replies. The user must be an active bot configured on {{setting:ask_discourse_context_admin_assistant_agent_id}}."
+    ask_discourse_context_admin_assistant_agent_id: "AI agent ID used for imported Admin Assistant chats. Its configured user must match {{setting:ask_discourse_context_admin_assistant_user_id}}."
+
   ask_discourse_context:
     sync_failed: "The Admin Assistant chat could not be synchronized."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,0 +1,3 @@
+en:
+  ask_discourse_context:
+    sync_failed: "The Admin Assistant chat could not be synchronized."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,5 +1,6 @@
 en:
   site_settings:
+    ask_discourse_context_admin_assistant_chat_sync_enabled: "Allow Admin Assistant chat snapshots to be synchronized into private messages."
     ask_discourse_context_admin_assistant_user_id: "User ID that authors imported Admin Assistant replies. The user must be an active bot configured on {{setting:ask_discourse_context_admin_assistant_agent_id}}."
     ask_discourse_context_admin_assistant_agent_id: "AI agent ID used for imported Admin Assistant chats. Its configured user must match {{setting:ask_discourse_context_admin_assistant_user_id}}."
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,6 @@
 ask_discourse_context:
+  ask_discourse_context_admin_assistant_chat_sync_enabled:
+    default: false
   ask_discourse_context_admin_assistant_user_id:
     type: integer
     default: -1206

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,8 @@
+ask_discourse_context:
+  ask_discourse_context_admin_assistant_user_id:
+    type: integer
+    default: -1206
+    min: -2000000000
+  ask_discourse_context_admin_assistant_agent_id:
+    type: integer
+    default: 2

--- a/lib/ask_discourse_context/admin_assistant_chat_snapshot.rb
+++ b/lib/ask_discourse_context/admin_assistant_chat_snapshot.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module AskDiscourseContext
+  class AdminAssistantChatSnapshot
+    Message =
+      Data.define(:external_id, :role, :raw, :created_at, :updated_at, :deleted_at) do
+        def active?
+          deleted_at.nil?
+        end
+
+        def admin?
+          role == "admin"
+        end
+      end
+
+    attr_reader :messages
+
+    def initialize(messages)
+      @messages =
+        messages.map do |message|
+          attributes = message.respond_to?(:to_unsafe_h) ? message.to_unsafe_h : message.to_h
+          attributes = attributes.stringify_keys
+
+          Message.new(
+            external_id: attributes.fetch("external_id").to_s,
+            role: attributes.fetch("role"),
+            raw: attributes.fetch("raw"),
+            created_at: Time.iso8601(attributes.fetch("created_at").to_s),
+            updated_at: Time.iso8601(attributes.fetch("updated_at").to_s),
+            deleted_at:
+              attributes["deleted_at"].present? ? Time.iso8601(attributes["deleted_at"].to_s) : nil,
+          )
+        end
+    end
+
+    def opening_message
+      messages.find(&:admin?)
+    end
+
+    def from(message_id:, started_at:)
+      if (index = messages.index { |message| message.external_id == message_id })
+        messages.drop(index)
+      else
+        messages.select { |message| message.created_at >= started_at }
+      end
+    end
+  end
+end

--- a/lib/ask_discourse_context/admin_assistant_chat_synchronizer.rb
+++ b/lib/ask_discourse_context/admin_assistant_chat_synchronizer.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+module AskDiscourseContext
+  class AdminAssistantChatSynchronizer
+    DELETED_FIRST_POST_RAW = "<!-- The imported source message was deleted. -->"
+    EDIT_REASON = "Admin Assistant chat synchronization"
+
+    class TopicConflict < StandardError
+    end
+
+    class AuthorConflict < StandardError
+    end
+
+    def initialize(actor:, agent_user:, external_id:, snapshot:, staged_user:, title:)
+      @actor = actor
+      @agent_user = agent_user
+      @external_id = external_id
+      @snapshot = snapshot
+      @staged_user = staged_user
+      @title = title
+    end
+
+    def sync
+      topic = Topic.with_deleted.find_by(external_id: @external_id)
+      ensure_topic_is_owned!(topic) if topic
+
+      return if !topic && !@snapshot.opening_message
+
+      topic ||= create_topic(@snapshot.opening_message)
+      recover_topic(topic)
+      reconcile_messages(topic)
+    end
+
+    private
+
+    def ensure_topic_is_owned!(topic)
+      if !topic.private_message? ||
+           !topic.custom_fields[AskDiscourseContext::TOPIC_SYNC_CUSTOM_FIELD] ||
+           topic.custom_fields[AskDiscourseContext::TOPIC_START_MESSAGE_ID_CUSTOM_FIELD].blank? ||
+           topic.custom_fields[AskDiscourseContext::TOPIC_STARTED_AT_CUSTOM_FIELD].blank?
+        raise TopicConflict
+      end
+    end
+
+    def create_topic(opening_message)
+      post =
+        create_post(
+          opening_message,
+          title: @title,
+          archetype: Archetype.private_message,
+          target_user_ids: [@agent_user.id],
+          external_id: @external_id,
+          topic_opts: {
+            custom_fields: {
+              AskDiscourseContext::TOPIC_SYNC_CUSTOM_FIELD => true,
+              AskDiscourseContext::TOPIC_START_MESSAGE_ID_CUSTOM_FIELD =>
+                opening_message.external_id,
+              AskDiscourseContext::TOPIC_STARTED_AT_CUSTOM_FIELD =>
+                opening_message.created_at.iso8601(6),
+            },
+          },
+        )
+      post.topic
+    end
+
+    def recover_topic(topic)
+      return if !topic.deleted_at
+
+      PostDestroyer.new(@actor, topic.first_post, context: EDIT_REASON).recover
+    end
+
+    def reconcile_messages(topic)
+      messages =
+        @snapshot.from(
+          message_id: topic.custom_fields[AskDiscourseContext::TOPIC_START_MESSAGE_ID_CUSTOM_FIELD],
+          started_at:
+            Time.iso8601(topic.custom_fields[AskDiscourseContext::TOPIC_STARTED_AT_CUSTOM_FIELD]),
+        )
+      posts = synchronized_posts(topic)
+
+      messages.each { |message| reconcile_message(message, posts[message.external_id], topic) }
+
+      missing_message_ids = posts.keys - messages.map(&:external_id)
+      missing_message_ids.each { |message_id| delete_post(posts.fetch(message_id), topic) }
+    end
+
+    def synchronized_posts(topic)
+      posts = topic.posts.with_deleted.to_a
+      message_ids =
+        PostCustomField
+          .where(post_id: posts.map(&:id), name: AskDiscourseContext::MESSAGE_ID_CUSTOM_FIELD)
+          .pluck(:post_id, :value)
+          .to_h
+
+      posts.filter_map { |post| [message_ids[post.id], post] if message_ids[post.id] }.to_h
+    end
+
+    def reconcile_message(message, post, topic)
+      ensure_author_matches!(message, post) if post
+
+      if message.active?
+        post ||= create_post(message, topic_id: topic.id)
+        recover_post(post) if post.deleted_at
+        revise_post(post, message, topic)
+        mark_source_deleted(post, false)
+      elsif post
+        delete_post(post, topic)
+      else
+        post = create_post(message, topic_id: topic.id)
+        delete_post(post, topic)
+      end
+    end
+
+    def ensure_author_matches!(message, post)
+      expected_user_id = message.admin? ? @staged_user.id : @agent_user.id
+      stored_role = post.custom_fields[AskDiscourseContext::MESSAGE_ROLE_CUSTOM_FIELD]
+
+      raise AuthorConflict if post.user_id != expected_user_id || stored_role != message.role
+    end
+
+    def create_post(message, options = {})
+      custom_fields = {
+        AskDiscourseContext::MESSAGE_ID_CUSTOM_FIELD => message.external_id,
+        AskDiscourseContext::MESSAGE_ROLE_CUSTOM_FIELD => message.role,
+        AskDiscourseContext::MESSAGE_DELETED_CUSTOM_FIELD => false,
+      }
+      if message.admin?
+        custom_fields[DiscourseAi::AiBot::Playground::BYPASS_AI_REPLY_CUSTOM_FIELD] = true
+      end
+
+      PostCreator.create!(
+        message.admin? ? @staged_user : @agent_user,
+        {
+          raw: message.raw,
+          acting_user: @actor,
+          guardian: @actor.guardian,
+          created_at: message.created_at,
+          custom_fields: custom_fields,
+          skip_validations: true,
+          post_alert_options: {
+            skip_send_email: true,
+          },
+        }.merge(options),
+      )
+    end
+
+    def revise_post(post, message, topic)
+      new_raw = message.raw
+      new_title = post.is_first_post? ? @title : nil
+      return if post.raw == new_raw && (!new_title || topic.title == new_title)
+
+      changes = { raw: new_raw, edit_reason: EDIT_REASON }
+      changes[:title] = new_title if new_title
+
+      PostRevisor.new(post, topic).revise!(
+        @actor,
+        changes,
+        bypass_bump: true,
+        force_new_version: true,
+        revised_at: message.updated_at,
+        silent: true,
+        skip_validations: true,
+      )
+    end
+
+    def delete_post(post, topic)
+      if post.is_first_post?
+        revise_deleted_first_post(post, topic)
+      elsif !post.deleted_at
+        PostDestroyer.new(@actor, post, context: EDIT_REASON, skip_staff_log: true).destroy
+        mark_source_deleted(post, true)
+      end
+    end
+
+    def revise_deleted_first_post(post, topic)
+      if post.raw != DELETED_FIRST_POST_RAW
+        PostRevisor.new(post, topic).revise!(
+          @actor,
+          { raw: DELETED_FIRST_POST_RAW, edit_reason: EDIT_REASON },
+          bypass_bump: true,
+          force_new_version: true,
+          silent: true,
+          skip_validations: true,
+        )
+      end
+      mark_source_deleted(post, true)
+    end
+
+    def recover_post(post)
+      PostDestroyer.new(@actor, post, context: EDIT_REASON, skip_staff_log: true).recover
+    end
+
+    def mark_source_deleted(post, deleted)
+      return if post.custom_fields[AskDiscourseContext::MESSAGE_DELETED_CUSTOM_FIELD] == deleted
+
+      post.custom_fields[AskDiscourseContext::MESSAGE_DELETED_CUSTOM_FIELD] = deleted
+      post.save_custom_fields
+    end
+  end
+end

--- a/lib/ask_discourse_context/staged_user.rb
+++ b/lib/ask_discourse_context/staged_user.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module AskDiscourseContext
+  class StagedUser
+    UNIQUE_ID_CUSTOM_FIELD = "ai-stream-conversation-unique-id"
+    MUTEX_VALIDITY = 30.seconds
+
+    class InvalidUser < StandardError
+    end
+
+    def self.find_or_create!(unique_id:, preferred_username:)
+      mutex_key = Digest::SHA256.hexdigest(unique_id)
+
+      DistributedMutex.synchronize(
+        "ask-discourse-context-staged-user-#{mutex_key}",
+        validity: MUTEX_VALIDITY,
+      ) do
+        user = UserCustomField.find_by(name: UNIQUE_ID_CUSTOM_FIELD, value: unique_id)&.user
+        raise InvalidUser if user && !user.staged?
+        next user if user
+
+        user =
+          User.new(
+            username: UserNameSuggester.suggest(preferred_username || unique_id),
+            email: "#{SecureRandom.hex}@invalid.com",
+            staged: true,
+            active: false,
+          )
+        user.custom_fields[UNIQUE_ID_CUSTOM_FIELD] = unique_id
+        user.save!
+        user
+      end
+    end
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,13 +1,63 @@
 # frozen_string_literal: true
 # name: ask-discourse-context
-# about: Adds AI Stream conversation unique ID to user cards
+# about: Adds customer context and hosted Admin Assistant chat ingestion
 # version: 0.1
 # authors: Sam
 # url: https://github.com/discourse/ask-discourse-context
 
-# The ask theme can then use this information to render links to sites
+module ::AskDiscourseContext
+  PLUGIN_NAME = "ask-discourse-context"
+  ADMIN_ASSISTANT_AGENT_ID = 2
+  ADMIN_ASSISTANT_USER_ID = -1206
+  # Source IDs make snapshot reconciliation idempotent without exposing metadata in PM bodies.
+  MESSAGE_ID_CUSTOM_FIELD = "ask_discourse_context_admin_assistant_message_id"
+  MESSAGE_ROLE_CUSTOM_FIELD = "ask_discourse_context_admin_assistant_message_role"
+  MESSAGE_DELETED_CUSTOM_FIELD = "ask_discourse_context_admin_assistant_message_deleted"
+  TOPIC_SYNC_CUSTOM_FIELD = "ask_discourse_context_admin_assistant_chat"
+  TOPIC_START_MESSAGE_ID_CUSTOM_FIELD = "ask_discourse_context_admin_assistant_start_message_id"
+  TOPIC_STARTED_AT_CUSTOM_FIELD = "ask_discourse_context_admin_assistant_started_at"
+end
+
+Discourse::Application.routes.append do
+  scope "/admin/plugins/ask-discourse-context", constraints: AdminConstraint.new do
+    put "/admin-assistant-chats/:external_id" =>
+          "ask_discourse_context/admin_assistant_chats#update",
+        :constraints => {
+          external_id: /[\w-]+/,
+        },
+        :defaults => {
+          format: :json,
+        }
+  end
+end
+
+add_api_key_scope(
+  :ask_discourse_context,
+  {
+    sync_admin_assistant_chats: {
+      actions: %w[ask_discourse_context/admin_assistant_chats#update],
+    },
+  },
+)
 
 after_initialize do
+  register_post_custom_field_type(AskDiscourseContext::MESSAGE_ID_CUSTOM_FIELD, :string)
+  register_post_custom_field_type(AskDiscourseContext::MESSAGE_ROLE_CUSTOM_FIELD, :string)
+  register_post_custom_field_type(AskDiscourseContext::MESSAGE_DELETED_CUSTOM_FIELD, :boolean)
+  register_topic_custom_field_type(AskDiscourseContext::TOPIC_SYNC_CUSTOM_FIELD, :boolean)
+  register_topic_custom_field_type(
+    AskDiscourseContext::TOPIC_START_MESSAGE_ID_CUSTOM_FIELD,
+    :string,
+  )
+  register_topic_custom_field_type(AskDiscourseContext::TOPIC_STARTED_AT_CUSTOM_FIELD, :string)
+
+  require_relative "lib/ask_discourse_context/admin_assistant_chat_snapshot"
+  require_relative "lib/ask_discourse_context/admin_assistant_chat_synchronizer"
+  require_relative "lib/ask_discourse_context/staged_user"
+  require_relative "app/services/ask_discourse_context/admin_assistant_chat/sync"
+  require_relative "app/controllers/ask_discourse_context/admin_assistant_chats_controller"
+
+  # The ask theme can then use this information to render links to sites
   add_to_serializer(
     :user_card,
     :ai_stream_conversation_unique_id,

--- a/plugin.rb
+++ b/plugin.rb
@@ -7,8 +7,6 @@
 
 module ::AskDiscourseContext
   PLUGIN_NAME = "ask-discourse-context"
-  ADMIN_ASSISTANT_AGENT_ID = 2
-  ADMIN_ASSISTANT_USER_ID = -1206
   # Source IDs make snapshot reconciliation idempotent without exposing metadata in PM bodies.
   MESSAGE_ID_CUSTOM_FIELD = "ask_discourse_context_admin_assistant_message_id"
   MESSAGE_ROLE_CUSTOM_FIELD = "ask_discourse_context_admin_assistant_message_role"

--- a/spec/requests/admin_assistant_chats_controller_spec.rb
+++ b/spec/requests/admin_assistant_chats_controller_spec.rb
@@ -6,12 +6,16 @@ RSpec.describe AskDiscourseContext::AdminAssistantChatsController do
   fab!(:assistant_user) do
     Fabricate(
       :user,
-      id: AskDiscourseContext::ADMIN_ASSISTANT_USER_ID,
+      id: SiteSetting.ask_discourse_context_admin_assistant_user_id,
       username: "ask_admin_assistant",
     )
   end
   fab!(:assistant_agent) do
-    Fabricate(:ai_agent, id: AskDiscourseContext::ADMIN_ASSISTANT_AGENT_ID, user: assistant_user)
+    Fabricate(
+      :ai_agent,
+      id: SiteSetting.ask_discourse_context_admin_assistant_agent_id,
+      user: assistant_user,
+    )
   end
 
   let(:external_id) { "admin-assistant-0123456789abcdef0123456789abcdef" }
@@ -412,6 +416,53 @@ RSpec.describe AskDiscourseContext::AdminAssistantChatsController do
       expect([first_topic.first_post.user_id, second_topic.first_post.user_id].uniq).to eq(
         [staged_fields.pick(:user_id)],
       )
+    end
+
+    it "uses the configured Admin Assistant agent and user" do
+      configured_user = Fabricate(:bot, username: "configured_assistant")
+      configured_agent = Fabricate(:ai_agent, id: 123_456, user: configured_user)
+      SiteSetting.ask_discourse_context_admin_assistant_user_id = configured_user.id
+      SiteSetting.ask_discourse_context_admin_assistant_agent_id = configured_agent.id
+      sign_in(admin)
+      messages = [
+        message(
+          external_id: 1,
+          role: "admin",
+          raw: "How do I configure this?",
+          created_at: started_at,
+        ),
+        message(
+          external_id: 2,
+          role: "assistant",
+          raw: "Open the settings page.",
+          created_at: started_at + 1.minute,
+        ),
+      ]
+
+      sync_chat(messages: messages)
+
+      topic = Topic.find_by!(external_id: external_id)
+      assistant_post = source_post(topic, 2)
+      expect(response).to have_http_status(:no_content)
+      expect(assistant_post.user).to eq(configured_user)
+    end
+
+    it "rejects an agent that does not belong to the configured user" do
+      SiteSetting.ask_discourse_context_admin_assistant_user_id = Fabricate(:bot).id
+      sign_in(admin)
+      messages = [
+        message(
+          external_id: 1,
+          role: "admin",
+          raw: "How do I configure this?",
+          created_at: started_at,
+        ),
+      ]
+
+      sync_chat(messages: messages)
+
+      expect(response).to have_http_status(:forbidden)
+      expect(Topic.exists?(external_id: external_id)).to eq(false)
     end
 
     it "rejects invalid roles, duplicate IDs, and out-of-order timestamps" do

--- a/spec/requests/admin_assistant_chats_controller_spec.rb
+++ b/spec/requests/admin_assistant_chats_controller_spec.rb
@@ -1,0 +1,501 @@
+# frozen_string_literal: true
+
+RSpec.describe AskDiscourseContext::AdminAssistantChatsController do
+  fab!(:admin)
+  fab!(:regular_user, :user)
+  fab!(:assistant_user) do
+    Fabricate(
+      :user,
+      id: AskDiscourseContext::ADMIN_ASSISTANT_USER_ID,
+      username: "ask_admin_assistant",
+    )
+  end
+  fab!(:assistant_agent) do
+    Fabricate(:ai_agent, id: AskDiscourseContext::ADMIN_ASSISTANT_AGENT_ID, user: assistant_user)
+  end
+
+  let(:external_id) { "admin-assistant-0123456789abcdef0123456789abcdef" }
+  let(:user_unique_id) { "https://example.com/u/source-admin" }
+  let(:title) { "Admin Assistant chat with source admin" }
+  let(:started_at) { Time.utc(2026, 7, 23, 12) }
+
+  def message(external_id:, role:, raw:, created_at:, updated_at: created_at, deleted_at: nil)
+    {
+      external_id: external_id.to_s,
+      role: role,
+      raw: raw,
+      created_at: created_at.iso8601(6),
+      updated_at: updated_at.iso8601(6),
+      deleted_at: deleted_at&.iso8601(6),
+    }
+  end
+
+  def payload(messages:, unique_id: user_unique_id, preferred_username: "source_admin")
+    {
+      user_unique_id: unique_id,
+      preferred_username: preferred_username,
+      title: title,
+      messages: messages,
+    }
+  end
+
+  def sync_chat(messages:, id: external_id, headers: nil, **payload_options)
+    put "/admin/plugins/ask-discourse-context/admin-assistant-chats/#{id}.json",
+        params: payload(messages: messages, **payload_options),
+        headers: headers,
+        as: :json
+  end
+
+  def source_post(topic, message_id)
+    custom_field =
+      PostCustomField.find_by(
+        name: AskDiscourseContext::MESSAGE_ID_CUSTOM_FIELD,
+        value: message_id.to_s,
+        post_id: topic.posts.with_deleted.select(:id),
+      )
+
+    Post.with_deleted.find(custom_field.post_id) if custom_field
+  end
+
+  describe "#update" do
+    it "requires an admin" do
+      messages = [
+        message(
+          external_id: 1,
+          role: "admin",
+          raw: "How do I configure this?",
+          created_at: started_at,
+        ),
+      ]
+
+      sync_chat(messages: messages)
+      expect(response).to have_http_status(:not_found)
+
+      sign_in(regular_user)
+      sync_chat(messages: messages)
+      expect(response).to have_http_status(:not_found)
+
+      expect(Topic.exists?(external_id: external_id)).to eq(false)
+    end
+
+    it "allows only the dedicated granular API-key scope" do
+      messages = [
+        message(
+          external_id: 1,
+          role: "admin",
+          raw: "How do I configure this?",
+          created_at: started_at,
+        ),
+      ]
+      scope =
+        Fabricate.build(
+          :api_key_scope,
+          resource: "ask_discourse_context",
+          action: "sync_admin_assistant_chats",
+        )
+      api_key = Fabricate(:api_key, user: admin, scope_mode: :granular, api_key_scopes: [scope])
+      headers = { "Api-Key" => api_key.key, "Api-Username" => admin.username }
+
+      sync_chat(messages: messages, headers: headers)
+
+      expect(response).to have_http_status(:no_content)
+      expect(Topic.exists?(external_id: external_id)).to eq(true)
+
+      scope.update!(action: "fake")
+      rejected_external_id = "admin-assistant-fedcba9876543210fedcba9876543210"
+
+      sync_chat(messages: messages, id: rejected_external_id, headers: headers)
+
+      expect(response).to have_http_status(:not_found)
+      expect(Topic.exists?(external_id: rejected_external_id)).to eq(false)
+    end
+
+    it "does nothing for an empty snapshot" do
+      sign_in(admin)
+
+      expect { sync_chat(messages: []) }.not_to change {
+        UserCustomField.where(name: AskDiscourseContext::StagedUser::UNIQUE_ID_CUSTOM_FIELD).count
+      }
+
+      expect(response).to have_http_status(:no_content)
+      expect(Topic.exists?(external_id: external_id)).to eq(false)
+    end
+
+    it "does nothing for an assistant welcome without an admin message" do
+      sign_in(admin)
+      messages = [
+        message(
+          external_id: 1,
+          role: "assistant",
+          raw: "Welcome! I am here to help.",
+          created_at: started_at,
+        ),
+      ]
+
+      expect { sync_chat(messages: messages) }.not_to change {
+        UserCustomField.where(name: AskDiscourseContext::StagedUser::UNIQUE_ID_CUSTOM_FIELD).count
+      }
+
+      expect(response).to have_http_status(:no_content)
+      expect(Topic.exists?(external_id: external_id)).to eq(false)
+    end
+
+    it "starts at the first admin message with the real authors and AI bypass field" do
+      sign_in(admin)
+      messages = [
+        message(
+          external_id: 1,
+          role: "assistant",
+          raw: "Welcome! I am here to help.",
+          created_at: started_at,
+        ),
+        message(
+          external_id: 2,
+          role: "admin",
+          raw: "How do I configure this?",
+          created_at: started_at + 1.minute,
+        ),
+        message(
+          external_id: 3,
+          role: "assistant",
+          raw: "Open the settings page.",
+          created_at: started_at + 2.minutes,
+        ),
+      ]
+
+      sync_chat(messages: messages)
+
+      expect(response).to have_http_status(:no_content)
+      topic = Topic.find_by!(external_id: external_id)
+      staged_user =
+        UserCustomField.find_by!(
+          name: AskDiscourseContext::StagedUser::UNIQUE_ID_CUSTOM_FIELD,
+          value: user_unique_id,
+        ).user
+      admin_post = source_post(topic, 2)
+      assistant_post = source_post(topic, 3)
+
+      expect(source_post(topic, 1)).to be_nil
+      expect(topic.topic_allowed_users.pluck(:user_id)).to contain_exactly(
+        staged_user.id,
+        assistant_user.id,
+      )
+      expect([admin_post.user, assistant_post.user]).to eq([staged_user, assistant_user])
+      expect(
+        admin_post.custom_fields[DiscourseAi::AiBot::Playground::BYPASS_AI_REPLY_CUSTOM_FIELD],
+      ).to be_present
+      expect(
+        assistant_post.custom_fields[DiscourseAi::AiBot::Playground::BYPASS_AI_REPLY_CUSTOM_FIELD],
+      ).to be_nil
+    end
+
+    it "is idempotent when the same snapshot is synchronized again" do
+      sign_in(admin)
+      messages = [
+        message(
+          external_id: 1,
+          role: "admin",
+          raw: "How do I configure this?",
+          created_at: started_at,
+        ),
+        message(
+          external_id: 2,
+          role: "assistant",
+          raw: "Open the settings page.",
+          created_at: started_at + 1.minute,
+        ),
+      ]
+
+      sync_chat(messages: messages)
+      topic = Topic.find_by!(external_id: external_id)
+      post_ids = topic.posts.order(:post_number).pluck(:id)
+      revision_count = PostRevision.where(post_id: post_ids).count
+
+      expect { sync_chat(messages: messages) }.not_to change { topic.posts.with_deleted.count }
+
+      expect(response).to have_http_status(:no_content)
+      expect(topic.posts.order(:post_number).pluck(:id)).to eq(post_ids)
+      expect(PostRevision.where(post_id: post_ids).count).to eq(revision_count)
+    end
+
+    it "edits, soft-deletes, and restores synchronized replies" do
+      sign_in(admin)
+      initial_messages = [
+        message(
+          external_id: 1,
+          role: "admin",
+          raw: "How do I configure this?",
+          created_at: started_at,
+        ),
+        message(
+          external_id: 2,
+          role: "assistant",
+          raw: "Open the settings page.",
+          created_at: started_at + 1.minute,
+        ),
+      ]
+      sync_chat(messages: initial_messages)
+      topic = Topic.find_by!(external_id: external_id)
+      assistant_post = source_post(topic, 2)
+
+      edited_messages = [
+        initial_messages.first,
+        message(
+          external_id: 2,
+          role: "assistant",
+          raw: "Open the AI settings page.",
+          created_at: started_at + 1.minute,
+          updated_at: started_at + 2.minutes,
+        ),
+      ]
+      sync_chat(messages: edited_messages)
+
+      expect(response).to have_http_status(:no_content)
+      expect(assistant_post.reload.raw).to eq("Open the AI settings page.")
+
+      deleted_messages = [
+        initial_messages.first,
+        message(
+          external_id: 2,
+          role: "assistant",
+          raw: "Open the AI settings page.",
+          created_at: started_at + 1.minute,
+          updated_at: started_at + 2.minutes,
+          deleted_at: started_at + 3.minutes,
+        ),
+      ]
+      sync_chat(messages: deleted_messages)
+
+      expect(response).to have_http_status(:no_content)
+      expect(assistant_post.reload.deleted_at).to be_present
+      expect(assistant_post.custom_fields[AskDiscourseContext::MESSAGE_DELETED_CUSTOM_FIELD]).to eq(
+        true,
+      )
+
+      sync_chat(messages: edited_messages)
+
+      expect(response).to have_http_status(:no_content)
+      expect(assistant_post.reload.deleted_at).to be_nil
+      expect(assistant_post.custom_fields[AskDiscourseContext::MESSAGE_DELETED_CUSTOM_FIELD]).to eq(
+        false,
+      )
+    end
+
+    it "uses the invisible placeholder for a deleted first admin message and restores it" do
+      sign_in(admin)
+      active_message =
+        message(
+          external_id: 1,
+          role: "admin",
+          raw: "How do I configure this?",
+          created_at: started_at,
+        )
+      sync_chat(messages: [active_message])
+      topic = Topic.find_by!(external_id: external_id)
+      first_post = topic.first_post
+
+      deleted_message =
+        message(
+          external_id: 1,
+          role: "admin",
+          raw: "How do I configure this?",
+          created_at: started_at,
+          updated_at: started_at + 1.minute,
+          deleted_at: started_at + 1.minute,
+        )
+      sync_chat(messages: [deleted_message])
+
+      expect(response).to have_http_status(:no_content)
+      expect(first_post.reload.raw).to eq(
+        AskDiscourseContext::AdminAssistantChatSynchronizer::DELETED_FIRST_POST_RAW,
+      )
+      expect(first_post.deleted_at).to be_nil
+      expect(first_post.custom_fields[AskDiscourseContext::MESSAGE_DELETED_CUSTOM_FIELD]).to eq(
+        true,
+      )
+      expect(topic.reload.deleted_at).to be_nil
+
+      sync_chat(messages: [active_message])
+
+      expect(response).to have_http_status(:no_content)
+      expect(first_post.reload.raw).to eq("How do I configure this?")
+      expect(first_post.custom_fields[AskDiscourseContext::MESSAGE_DELETED_CUSTOM_FIELD]).to eq(
+        false,
+      )
+    end
+
+    it "creates a traceable PM when its first observed admin message is already deleted" do
+      sign_in(admin)
+      deleted_message =
+        message(
+          external_id: 1,
+          role: "admin",
+          raw: "A message deleted between snapshots",
+          created_at: started_at,
+          updated_at: started_at + 1.minute,
+          deleted_at: started_at + 1.minute,
+        )
+
+      sync_chat(messages: [deleted_message])
+
+      expect(response).to have_http_status(:no_content)
+      topic = Topic.find_by!(external_id: external_id)
+      first_post = source_post(topic, 1)
+      expect(first_post.raw).to eq(
+        AskDiscourseContext::AdminAssistantChatSynchronizer::DELETED_FIRST_POST_RAW,
+      )
+      expect(first_post.custom_fields[AskDiscourseContext::MESSAGE_ID_CUSTOM_FIELD]).to eq("1")
+      expect(first_post.custom_fields[AskDiscourseContext::MESSAGE_DELETED_CUSTOM_FIELD]).to eq(
+        true,
+      )
+    end
+
+    it "deletes omitted synchronized posts and preserves Ask-native posts" do
+      sign_in(admin)
+      initial_messages = [
+        message(
+          external_id: 1,
+          role: "admin",
+          raw: "How do I configure this?",
+          created_at: started_at,
+        ),
+        message(
+          external_id: 2,
+          role: "assistant",
+          raw: "Open the settings page.",
+          created_at: started_at + 1.minute,
+        ),
+      ]
+      sync_chat(messages: initial_messages)
+      topic = Topic.find_by!(external_id: external_id)
+      synchronized_reply = source_post(topic, 2)
+      native_post =
+        PostCreator.create!(
+          admin,
+          topic_id: topic.id,
+          raw: "A reply written directly on Ask",
+          skip_validations: true,
+        )
+
+      sync_chat(messages: [initial_messages.first])
+
+      expect(response).to have_http_status(:no_content)
+      expect(synchronized_reply.reload.deleted_at).to be_present
+      expect(native_post.reload.deleted_at).to be_nil
+    end
+
+    it "reuses a staged user across conversations with the same unique ID" do
+      sign_in(admin)
+      messages = [
+        message(
+          external_id: 1,
+          role: "admin",
+          raw: "How do I configure this?",
+          created_at: started_at,
+        ),
+      ]
+      other_external_id = "admin-assistant-fedcba9876543210fedcba9876543210"
+
+      sync_chat(messages: messages)
+      sync_chat(messages: messages, id: other_external_id)
+
+      expect(response).to have_http_status(:no_content)
+      first_topic = Topic.find_by!(external_id: external_id)
+      second_topic = Topic.find_by!(external_id: other_external_id)
+      staged_fields =
+        UserCustomField.where(
+          name: AskDiscourseContext::StagedUser::UNIQUE_ID_CUSTOM_FIELD,
+          value: user_unique_id,
+        )
+
+      expect(staged_fields.count).to eq(1)
+      expect([first_topic.first_post.user_id, second_topic.first_post.user_id].uniq).to eq(
+        [staged_fields.pick(:user_id)],
+      )
+    end
+
+    it "rejects invalid roles, duplicate IDs, and out-of-order timestamps" do
+      sign_in(admin)
+      valid_admin =
+        message(
+          external_id: 1,
+          role: "admin",
+          raw: "How do I configure this?",
+          created_at: started_at,
+        )
+
+      invalid_role = valid_admin.merge(role: "system")
+      sync_chat(messages: [invalid_role])
+      expect(response).to have_http_status(:bad_request)
+
+      duplicate_id =
+        message(
+          external_id: 1,
+          role: "assistant",
+          raw: "Open the settings page.",
+          created_at: started_at + 1.minute,
+        )
+      sync_chat(messages: [valid_admin, duplicate_id])
+      expect(response).to have_http_status(:bad_request)
+
+      earlier_reply =
+        message(
+          external_id: 2,
+          role: "assistant",
+          raw: "Open the settings page.",
+          created_at: started_at - 1.minute,
+        )
+      sync_chat(messages: [valid_admin, earlier_reply])
+      expect(response).to have_http_status(:bad_request)
+
+      expect(Topic.exists?(external_id: external_id)).to eq(false)
+    end
+
+    it "rejects an external ID collision" do
+      sign_in(admin)
+      Fabricate(:topic, external_id: external_id)
+      messages = [
+        message(
+          external_id: 1,
+          role: "admin",
+          raw: "How do I configure this?",
+          created_at: started_at,
+        ),
+      ]
+
+      sync_chat(messages: messages)
+
+      expect(response).not_to have_http_status(:no_content)
+      expect(Topic.find_by!(external_id: external_id).private_message?).to eq(false)
+    end
+
+    it "rejects a source message whose author role changes" do
+      sign_in(admin)
+      admin_message =
+        message(
+          external_id: 1,
+          role: "admin",
+          raw: "How do I configure this?",
+          created_at: started_at,
+        )
+      sync_chat(messages: [admin_message])
+      topic = Topic.find_by!(external_id: external_id)
+      first_post = topic.first_post
+
+      conflicting_message =
+        message(
+          external_id: 1,
+          role: "assistant",
+          raw: "How do I configure this?",
+          created_at: started_at,
+        )
+      sync_chat(messages: [conflicting_message])
+
+      expect(response).not_to have_http_status(:no_content)
+      expect(first_post.reload.user.staged?).to eq(true)
+      expect(first_post.custom_fields[AskDiscourseContext::MESSAGE_ROLE_CUSTOM_FIELD]).to eq(
+        "admin",
+      )
+    end
+  end
+end

--- a/spec/requests/admin_assistant_chats_controller_spec.rb
+++ b/spec/requests/admin_assistant_chats_controller_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe AskDiscourseContext::AdminAssistantChatsController do
   let(:title) { "Admin Assistant chat with source admin" }
   let(:started_at) { Time.utc(2026, 7, 23, 12) }
 
+  before { SiteSetting.ask_discourse_context_admin_assistant_chat_sync_enabled = true }
+
   def message(external_id:, role:, raw:, created_at:, updated_at: created_at, deleted_at: nil)
     {
       external_id: external_id.to_s,
@@ -62,6 +64,24 @@ RSpec.describe AskDiscourseContext::AdminAssistantChatsController do
   end
 
   describe "#update" do
+    it "is unavailable when Admin Assistant chat synchronization is disabled" do
+      SiteSetting.ask_discourse_context_admin_assistant_chat_sync_enabled = false
+      sign_in(admin)
+      messages = [
+        message(
+          external_id: 1,
+          role: "admin",
+          raw: "How do I configure this?",
+          created_at: started_at,
+        ),
+      ]
+
+      sync_chat(messages: messages)
+
+      expect(response).to have_http_status(:not_found)
+      expect(Topic.exists?(external_id: external_id)).to eq(false)
+    end
+
     it "requires an admin" do
       messages = [
         message(


### PR DESCRIPTION
Previously, Admin Assistant ingestion was coupled to hard-coded Ask agent and bot user IDs.

This change adds a feature-gated, plugin-owned ingestion endpoint that turns a hosted site's Admin Assistant chat snapshot into a normal Ask Discourse PM, with server-side settings selecting the trusted agent and bot identities. It does not invoke an LLM or send replies back to the hosted site.

## Endpoint

`PUT /admin/plugins/ask-discourse-context/admin-assistant-chats/:external_id.json`

The endpoint is disabled by default. Set `ask_discourse_context_admin_assistant_chat_sync_enabled` to `true` to make it available; while disabled, requests return 404 before ingestion starts.

The endpoint is admin-only and exposes the dedicated granular API-key scope `ask_discourse_context:sync_admin_assistant_chats`. Callers cannot choose an arbitrary Ask author or recipient.

The server-only site settings are:

- `ask_discourse_context_admin_assistant_chat_sync_enabled`, default `false`;
- `ask_discourse_context_admin_assistant_agent_id`, default `2`;
- `ask_discourse_context_admin_assistant_user_id`, default `-1206`.

The configured agent must belong to the configured active bot user or ingestion is rejected.

Each request contains one complete, ordered chat snapshot:

```json
{
  "user_unique_id": "https://community.example.com/u/alice",
  "preferred_username": "alice",
  "title": "Admin Assistant chat with @alice on community.example.com",
  "messages": [
    {
      "external_id": "456",
      "role": "admin",
      "raw": "How do I configure this?",
      "created_at": "2026-07-23T12:00:00.000000Z",
      "updated_at": "2026-07-23T12:00:00.000000Z",
      "deleted_at": null
    },
    {
      "external_id": "457",
      "role": "assistant",
      "raw": "Open the settings page.",
      "created_at": "2026-07-23T12:01:00.000000Z",
      "updated_at": "2026-07-23T12:01:00.000000Z",
      "deleted_at": null
    }
  ]
}
```

## PM representation

The source admin is created or reused as a staged user using the same `ai-stream-conversation-unique-id` field as the existing AI Agents streaming endpoint. Admin messages are authored by that staged user, while assistant messages are authored by the configured bot user. Imported admin posts carry the AI-reply bypass field before `post_created`, so ingestion cannot start an Ask AI response.

An empty snapshot or an assistant welcome without any admin message is a no-op: no staged user or PM is created. A deleted admin message still proves the feature was used and can establish the PM without exposing deleted text.

## Reconciliation

The PM topic uses the caller's validated `external_id`. Source message IDs and roles are stored in post custom fields, making retries idempotent without adding invisible markers to rendered PM content.

Synchronization runs under a per-conversation lock and:

- revises edited messages with `PostRevisor`;
- soft-deletes and restores replies with `PostDestroyer`;
- replaces a deleted opening post with an invisible HTML comment so the PM itself remains available;
- deletes imported posts omitted from a later complete snapshot;
- preserves every Ask-native post that does not carry a source-message custom field;
- rejects topic ownership collisions and author/role changes.

Requests are bounded to 1,000 messages and 10 MB of raw content, with per-message length, unique source ID, role, timestamp, ordering, title, and external-ID validation.

Ask PMs remain report-only. Replies written on Ask are not synchronized back to the hosted chat.

## Deployment

Deploy this PR before enabling the hosted-site uploader. Configure its existing Ask API credentials with an Ask admin identity and the `ask_discourse_context:sync_admin_assistant_chats` granular scope, then enable `ask_discourse_context_admin_assistant_chat_sync_enabled` on Ask.

## Test plan

- [x] Returns 404 while Admin Assistant chat ingestion is disabled
- [x] Requires an admin or correctly scoped granular API key
- [x] Leaves empty and welcome-only snapshots as no-ops
- [x] Filters the pre-conversation welcome message
- [x] Creates posts with the real staged-admin and configured-bot authors
- [x] Uses the default agent `2` and bot user `-1206`
- [x] Supports overriding both trusted identities through site settings
- [x] Rejects agents that do not belong to the configured active bot
- [x] Sets the AI-reply bypass field before importing admin posts
- [x] Replays identical snapshots without duplicates or revisions
- [x] Reconciles edits, deletions, restorations, and omitted source posts
- [x] Handles deletion and restoration of the opening message
- [x] Preserves Ask-native replies
- [x] Reuses one staged user across multiple conversations
- [x] Rejects malformed snapshots, external-ID collisions, and role conflicts

Local verification: all plugin request specs 19 examples, 0 failures; all changed-file lints pass.
