### PR TITLE
I18N: Add Admin Assistant chat API scope description

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,0 +1,8 @@
+en:
+  admin_js:
+    admin:
+      api:
+        scopes:
+          descriptions:
+            ask_discourse_context:
+              sync_admin_assistant_chats: "Synchronize Admin Assistant chat snapshots into private messages"


### PR DESCRIPTION
Previously, the Admin Assistant chat synchronization scope was displayed without a human-readable description when creating granular API keys.

This change adds the scope description so administrators can identify its purpose.